### PR TITLE
Add padding to .content-container

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -89,6 +89,7 @@ textarea {
 .content-container {
   max-width: 36rem;
   text-align: center;
+  padding: 0 8px;
 }
 
 /* Update url-input width to be 100% since container will control max width */


### PR DESCRIPTION
Add padding to `.content-container` to add space between content and screen edge. For desktop browser, it is unnoticeable. However, in mobile browser, the content expand to both screen edges.

Before:
![k-1](https://github.com/user-attachments/assets/05b20419-7d65-4a44-8be2-7baa44afdab8)


After:
![k-2](https://github.com/user-attachments/assets/3c0899e2-384f-4f5c-a82f-ced4b7a3286e)
