### PR TITLE
Add OpenSearch Metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
       name="description"
       content="A better default search engine (with bangs!)"
     />
+    <link rel="search" type="application/opensearchdescription+xml" title="Unduck" href="/opensearch.xml">
   </head>
   <body style="background-color: transparent">
     <div id="app"></div>

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>Unduck</ShortName>
+    <Description>DuckDuckGo's bang redirects are too slow.</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Url type="text/html" template="https://unduck.link?q={searchTerms}"/>
+</OpenSearchDescription>


### PR DESCRIPTION
This adds a context menu button to the address bar for adding Unduck as a search engine (in Firefox; I can't speak for other browsers).