### PR TITLE
Dark-mode styling

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -61,6 +61,7 @@ h6 {
 a {
   color: #444444;
 }
+
 a:hover {
   color: #888888;
 }
@@ -147,4 +148,49 @@ textarea {
 
 .footer a:hover {
   color: #333;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #ddd;
+  }
+
+  #app {
+    background-color: #131313;
+  }
+
+  a {
+    color: #a9a9a9;
+  }
+
+  a:hover {
+    color: #888;
+  }
+
+  .footer,
+  .footer a {
+    color: #999;
+  }
+
+  .footer a:hover {
+    color: #ccc;
+  }
+
+  .url-input {
+    border-color: #3d3d3d;
+    background-color: #191919;
+    color: #fff;
+  }
+
+  .copy-button img {
+    filter: invert(1);
+  }
+
+  .copy-button:hover {
+    background: #222;
+  }
+
+  .copy-button:active {
+    background: #333;
+  }
 }


### PR DESCRIPTION
User that has `prefers-color-scheme` as `dark` will automatically see the dark mode version.

I override color only when neccessary to keep the changes as minimal as possible. The shade schemes are selected based on the original shade. As an example, original font color for `body` is darker than `a`, and `a` is darker than `a:hover`. Hence, in dark-mode, I used opposite shade: `body` is brighter than `a`, and `a` is brighter than `a:hover`.

Although `.copy-button` has `color` property, I don't override this color since there is no text in the element. If text would be included in the future, the following properties could be add:
```css
@media (prefers-color-scheme: dark) {
  .copy-button {
    color: #fff;
  }
}
```

