### PR TITLE
if the only thing in the query is a bang, redirect to homepage instead of the search page

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -63,12 +63,16 @@ function getBangredirectUrl() {
   // Remove the first bang from the query
   const cleanQuery = query.replace(/!\S+\s*/i, "").trim();
 
+  // If the query is just `!gh`, use `github.com` instead of `github.com/search?q=`
+  if (cleanQuery === "")
+    return selectedBang ? `https://${selectedBang.d}` : null;
+
   // Format of the url is:
   // https://www.google.com/search?q={{{s}}}
   const searchUrl = selectedBang?.u.replace(
     "{{{s}}}",
     // Replace %2F with / to fix formats like "!ghr+t3dotgg/unduck"
-    encodeURIComponent(cleanQuery).replace(/%2F/g, "/")
+    encodeURIComponent(cleanQuery).replace(/%2F/g, "/"),
   );
   if (!searchUrl) return null;
 


### PR DESCRIPTION
Fixes #23 
This makes `unduck.link/q=!gh` redirect to `github.com` instead of `github.com/search?q=`