### PR TITLE
use css text-wrap-style: pretty

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -92,6 +92,10 @@ textarea {
   padding: 0 8px;
 }
 
+.content-container p {
+  text-wrap: pretty;
+}
+
 /* Update url-input width to be 100% since container will control max width */
 .url-input {
   padding: 8px 12px;


### PR DESCRIPTION
The last page of the paragraph is just 1 word and it doesn't look good. This pr adds [text-wrap: pretty](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#pretty) to fix that.

| BEFORE | AFTER |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/2e75914b-e51e-4f26-8f04-b7b94dd9a463) | ![image](https://github.com/user-attachments/assets/587b4bf2-b6be-46dc-b09f-d7de203b3501) |