### PR TITLE
Register as a search engine

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,8 @@
       name="description"
       content="A better default search engine (with bangs!)"
     />
+
+    <link title="Unduck" type="application/opensearchdescription+xml" rel="search" href="/opensearch.xml">
   </head>
   <body style="background-color: transparent">
     <div id="app"></div>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>Unduck</ShortName>
+    <Description>Search Unduck</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <LongName>Unduck Search</LongName>
+    <Image height="16" width="16">
+        data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAJBQTFRFAAAABgYGMjIyKioqBQUFampq9vb2////7+/vTU1NZWVliYmJGBgYIiIipKSkCwsL8vLym5ubvb294eHhQEBALS0tUVFRGxsbRkZGLCwsVFRUHBwcFhYW/v7+mZmZvr6+5eXlAwMDdnZ2paWlnJycbW1t+Pj4sbGxfHx8MzMzJCQkiIiIi4uLe3t7NDQ0AgICg0dB1QAAAIVJREFUeJxjZEADjNgFGIHgD5IAKyMjUOw7XIDrLwtQxU+m71ABfkbG90CWEONbqIDIZ77XQJbYR4GXEAGJ90LPgSyptyJPIQIyjIyPgCx5Rsb7UEOVnrJwMvA/kb0Dt1aV8SEDj8gDxRsIh2kwXmPQvqN6BdXpurfUL6H6RY/xIi7PIQEAAUEdEQKpKxEAAAAASUVORK5CYII=</Image>
+    <Url type="text/html" method="get" template="https://unduck.link?q={searchTerms}" />
+    <!-- I'll leave this here in case you'd like to add a default suggestions engine -->
+    <!-- <Url type="application/x-suggestions+json"
+        template="https://duckduckgo.com/ac/?q={searchTerms}&amp;type=list" /> -->
+</OpenSearchDescription>


### PR DESCRIPTION
This allows a website to describe a search engine for itself, so that a browser or other client application can use that search engine. OpenSearch is supported by (at least) Firefox, Edge, Safari, and Chrome.