### PR TITLE
Automatically add unduck to the suggested search engines list on the browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,12 @@
       name="description"
       content="A better default search engine (with bangs!)"
     />
+    <link
+      rel="search"
+      type="application/opensearchdescription+xml"
+      href="/opensearch.xml"
+      title="Unduck Search Engine"
+    />
   </head>
   <body style="background-color: transparent">
     <div id="app"></div>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>Unduck.link</ShortName>
+    <Description>DuckDuckGo's bangs without the slowness</Description>
+    <Url type="text/html" template="https://unduck.link?q={searchTerms}" />
+</OpenSearchDescription>


### PR DESCRIPTION
added the opensearch.xml info to allow browsers to automatically add unduck to the suggested searchengines list.