### PR TITLE
fix: update !yfd bang URL

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -119882,7 +119882,7 @@ export const bangs = [
     s: "Yufid",
     sc: "Reference (religion)",
     t: "yfd",
-    u: "http://yufid.com/result/?search={{{s}}} ",
+    u: "https://yufid.com/result.html?search={{{s}}}",
   },
   {
     c: "News",


### PR DESCRIPTION
This commit updates the URL for the Yufid ("yfd") bang to use HTTPS for security and changes the endpoint to `result.html` to align with the expected resource.