### PR TITLE
Update background image to fit

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -39,6 +39,7 @@ html,
 body {
   height: 100%;
   width: 100%;
+  background-size: cover;
 }
 
 body {


### PR DESCRIPTION
On large monitors, Unduck can cause backgrounds not to fit. Adding the CSS property `background-size: cover;` to the HTML tag fixes this behavior

**Previous:**
![image](https://github.com/user-attachments/assets/f29499c2-771f-4097-a470-b067fba6504d)

**Fixed:**
![image](https://github.com/user-attachments/assets/99cb17d1-cc50-4039-adee-346d1d37c857)
