### PR TITLE
Adding Opensearch compatibility

### DIFF
--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,7 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Und*ck</ShortName>
+  <Description>Search using DuckDuckGo bangs via Und*ck</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">https://unduck.link/search.svg</Image>
+  <Url type="text/html" method="get" template="https://unduck.link?q={searchTerms}"/>
+</OpenSearchDescription>head

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ function noSearchDefaultPageRender() {
   const app = document.querySelector<HTMLDivElement>("#app")!;
   app.innerHTML = `
     <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh;">
+      <link rel="search" type="application/opensearchdescription+xml" title="Und*ck" href="/opensearch.xml">
       <div class="content-container">
         <h1>Und*ck</h1>
         <p>DuckDuckGo's bang redirects are too slow. Add the following URL as a custom search engine to your browser. Enables <a href="https://duckduckgo.com/bang.html" target="_blank">all of DuckDuckGo's bangs.</a></p>


### PR DESCRIPTION
Adding [OpenSearch](https://developer.mozilla.org/en-US/docs/Web/XML/Guides/OpenSearch), so firefox users can quickly add the search engine via rightclick.
