### PR TITLE
Fix gog.com bang

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -43143,7 +43143,7 @@ export const bangs = [
     s: "GOG.com",
     sc: "Games (general)",
     t: "gog",
-    u: "https://www.gog.com/games?search={{{s}}}",
+    u: "https://www.gog.com/games?query={{{s}}}",
   },
   {
     c: "Tech",


### PR DESCRIPTION
Fix the `!gog` bang by updating the query param name for [GOG.com](https://www.gog.com/).