### PR TITLE
Added default bangs through URL param with UI to pick default bang

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -61,6 +61,7 @@ h6 {
 a {
   color: #444444;
 }
+
 a:hover {
   color: #888888;
 }
@@ -147,4 +148,48 @@ textarea {
 
 .footer a:hover {
   color: #333;
+}
+
+.bang-form {
+  margin-top: 32px;
+  text-align: left;
+}
+
+label {
+  width: 100%;
+  font-size: inherit;
+  color: inherit;
+  font-family: inherit;
+}
+
+.bang-container {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+
+.bang-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #f5f5f5;
+}
+
+input[type="submit"] {
+  font-family: inherit;
+  font-size: 0.8em;
+  aspect-ratio: 1;
+  border: none;
+  background: transparent;
+}
+
+.bang-error {
+  margin-top: 8px;
+  color: crimson;
+}
+
+.bang-error>a {
+  color: inherit;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,8 +44,24 @@ function noSearchDefaultPageRender() {
   });
 }
 
-const LS_DEFAULT_BANG = localStorage.getItem("default-bang") ?? "g";
-const defaultBang = bangs.find((b) => b.t === LS_DEFAULT_BANG);
+function findBang(url: URL) {
+  //Honoring legacy local-storage defined bangs
+  const LS_DEFAULT_BANG = localStorage.getItem("default-bang");
+  if (LS_DEFAULT_BANG) {
+    const defaultBang = bangs.find((b) => b.t === LS_DEFAULT_BANG);
+    if (defaultBang)
+      return defaultBang;
+  }
+
+  //Obtaining default bang from URL
+  const URL_DEFAULT_BANG = url.searchParams.get("default_bang")?.trim() ?? "g"; //can contain invalid bang
+  const defaultUrlBang = bangs.find((b) => b.t == URL_DEFAULT_BANG);
+  if (defaultUrlBang)
+    return defaultUrlBang;
+
+  //In case everything else is invalid
+  return bangs.find((b) => b.t == "g")!;
+}
 
 function getBangredirectUrl() {
   const url = new URL(window.location.href);
@@ -58,7 +74,7 @@ function getBangredirectUrl() {
   const match = query.match(/!(\S+)/i);
 
   const bangCandidate = match?.[1]?.toLowerCase();
-  const selectedBang = bangs.find((b) => b.t === bangCandidate) ?? defaultBang;
+  const selectedBang = bangs.find((b) => b.t === bangCandidate) ?? findBang(url);
 
   // Remove the first bang from the query
   const cleanQuery = query.replace(/!\S+\s*/i, "").trim();

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,22 @@ function noSearchDefaultPageRender() {
             <img src="/clipboard.svg" alt="Copy" />
           </button>
         </div>
+        <form class="bang-form">
+          <label for="bang-input">Care to pick a default bang?</label>
+          <div class="bang-container">
+            <input
+              id="bang-input"
+              type="text"
+              class="bang-input"
+              value="g"
+              list="bang-list"
+              spellcheck="false"
+            />
+            <input type="submit" value="Apply" class"bang-confirm"/>
+          </div>
+          <datalist id="bang-list"></datalist>
+        </form>
+        <p class="bang-error"></p>
       </div>
       <footer class="footer">
         <a href="https://t3.chat" target="_blank">t3.chat</a>
@@ -33,6 +49,27 @@ function noSearchDefaultPageRender() {
   const copyButton = app.querySelector<HTMLButtonElement>(".copy-button")!;
   const copyIcon = copyButton.querySelector("img")!;
   const urlInput = app.querySelector<HTMLInputElement>(".url-input")!;
+  const bangDatalist = app.querySelector<HTMLDataListElement>("#bang-list")!;
+  const bangForm = app.querySelector<HTMLFormElement>(".bang-form")!;
+  const bangInput = app.querySelector<HTMLInputElement>("#bang-input")!;
+  const bangErrorDiv = app.querySelector<HTMLParagraphElement>(".bang-error")!;
+
+  bangs.forEach((b) => {
+    const option = document.createElement("option");
+    option.value = b.t;
+    bangDatalist.appendChild(option);
+  })
+
+  bangForm.addEventListener("submit", (submitEvent: SubmitEvent) => {
+    submitEvent.preventDefault();
+    const bangName = bangInput.value.trim();
+    if (!bangs.find((b) => b.t === bangName)) {
+      bangErrorDiv.innerHTML = `This bang is not known. Check the <a href="https://duckduckgo.com/bang.html" target="_blank">list of available bangs.</a>`;
+      return;
+    }
+    bangErrorDiv.innerHTML = "";
+    urlInput.value = `https://unduck.link?q=%s&default_bang=${encodeURIComponent(bangName)}`;
+  })
 
   copyButton.addEventListener("click", async () => {
     await navigator.clipboard.writeText(urlInput.value);


### PR DESCRIPTION
This PR adds default bangs in URL params through `default_bang`.

- Local storage is still honored if set
- Fallback in case of invalid bang has been hardened
- A UI has been added to let users pick their default bang

Why add this PR:
- This would enable mobile users to pick a default without the use of dev tools
- Simplifies the default bang selection for non techie users
- It's just nice

On a more note. This is my first PR to a public project. Let me know if anything can be improved!