### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine3.21 AS build
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+WORKDIR /app
+COPY package*.json pnpm-lock.yaml public src index.html tsconfig.json vite.config.ts ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile \
+    && pnpm build
+
+FROM nginx:alpine3.21
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ function noSearchDefaultPageRender() {
           <input 
             type="text" 
             class="url-input"
-            value="https://unduck.link?q=%s"
+            value="${window.location.origin}?q=%s"
             readonly 
           />
           <button class="copy-button">


### PR DESCRIPTION
- Add Dockerfile
- replace hard-coded unduck.link from input field with `window.location.origin`

I've seen a few Pull Requests add a Dockerfile and docker-compose, but they have been using `npm` rather than `pnpm` as the repo uses, shown by the existence of `pnpm-lock.yml`. This Dockerfile installs packages using `pnpm` and the lockfile. I've opted to not include a README addition, as I'm unsure whether there's a preference for committing docker-composes here, but a docker-compose might look like:

```yaml
services:
  unduck:
    build:
      context: .
    restart: 'unless-stopped'
    ports:
      - ${UNDUCK_PORT:-80}:80
```

This also includes a replacement of the unduck URL on the HTML page with a call to `window.location.origin`, so that it may be more easily self-hosted.