### PR TITLE
feat: add 'udm=14' to google url

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -41217,7 +41217,7 @@ export const bangs = [
     s: "Google",
     sc: "Google",
     t: "g",
-    u: "https://www.google.com/search?q={{{s}}}",
+    u: "https://www.google.com/search?udm=14&q={{{s}}}",
   },
   {
     c: "Online Services",


### PR DESCRIPTION
Modified the google url to use 'udm=14' so that it always redirects to 'web' results on google.