### PR TITLE
Changed "RealTimeTrains"

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -90498,7 +90498,7 @@ export const bangs = [
     s: "Real Time Trains",
     sc: "Tracking",
     t: "rtt",
-    u: "http://www.realtimetrains.co.uk/search/handler?type=basic&qs=true&search={{{s}}}",
+    u: "https://www.realtimetrains.co.uk/search/handler?qsearch={{{s}}}&type=detailed",
   },
   {
     c: "Entertainment",


### PR DESCRIPTION
Updates the RealTimeTrains search link (https://www.realtimetrains.co.uk/search/handler?qsearch={{{s}}}&type=detailed) to use their detailed search handler instead of the basic one. This allows for more flexible searches, including searching by train unit identifiers and location names, instead of just station codes, which was not previously possible with the old link (http://www.realtimetrains.co.uk/search/handler?type=basic&qs=true&search={{{s}}}).