### PR TITLE
Support appending extra queries for Google

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -63,18 +63,33 @@ function getBangredirectUrl() {
   // Remove the first bang from the query
   const cleanQuery = query.replace(/!\S+\s*/i, "").trim();
 
+  // Collect additional query parameters (excluding 'q')
+  const additionalParams = Array.from(url.searchParams.entries())
+    .filter(([key]) => key !== "q")
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join("&");
+
   // If the query is just `!gh`, use `github.com` instead of `github.com/search?q=`
   if (cleanQuery === "")
-    return selectedBang ? `https://${selectedBang.d}` : null;
+    return selectedBang
+      ? `https://${selectedBang.d}${additionalParams ? `?${additionalParams}` : ""}`
+      : null;
 
-  // Format of the url is:
+  // Format of the URL is:
   // https://www.google.com/search?q={{{s}}}
-  const searchUrl = selectedBang?.u.replace(
+  let searchUrl = selectedBang?.u.replace(
     "{{{s}}}",
     // Replace %2F with / to fix formats like "!ghr+t3dotgg/unduck"
     encodeURIComponent(cleanQuery).replace(/%2F/g, "/"),
   );
+
   if (!searchUrl) return null;
+
+  // Only append additional parameters if the selected bang is the default bang (Google)
+  if (selectedBang?.t === defaultBang?.t && additionalParams) {
+    const delimiter = searchUrl.includes("?") ? "&" : "?";
+    searchUrl += `${delimiter}${additionalParams}`;
+  }
 
   return searchUrl;
 }


### PR DESCRIPTION
If the default bang is being used (Google), append any additional queries `?` found other than the original `q=%s` query.

This allows for additional queries to be passed to Google whenever the default bang is used, and extends functionality for us power users out there.

This PR was originally made so that unduck wouldn't ignore the `udm=14` query I was passing it in my search engine settings, but it can be used for any similar params you can think of that Google supports.

These additional queries will still be ignored if using any bang other than Google (for obvious reasons).

This is what the URL looks like in my Search Engine settings for my browser:

`https://unduck.link?q=%s&udm=14` (also see pic below)

![image](https://github.com/user-attachments/assets/00a360fb-da1f-432e-a188-8d6cb6b40d24)

Took the idea from [this ThioJoe video](https://www.youtube.com/watch?v=qGlNb2ZPZdc).

I wanted to use `udm=14`, but you can't use both this extra param _and_ unduck simultaneously, without my suggested changes.

Would love to see this be merged, I think this would be cool for a lot of people. 💪💪