### PR TITLE
feat: Add OpenSearch support for browser integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
     />
     <link
+      rel="search"
+      type="application/opensearchdescription+xml"
+      title="Unduck"
+      href="/opensearch.xml"
+    />
+    <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       media="print"

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription
+	xmlns="http://a9.com/-/spec/opensearch/1.1/"
+	xmlns:moz="http://www.mozilla.org/addons/opensearch/">
+	<ShortName>Unduck</ShortName>
+	<Description>A better default search engine (with bangs!)</Description>
+	<Tags>unduck bangs</Tags>
+	<Url type="text/html" method="GET" template="https://unduck.link/?q={searchTerms}"/>
+	<Image height="16" width="16" type="image/svg+xml">https://unduck.link/search.svg</Image>
+	<InputEncoding>UTF-8</InputEncoding>
+	<OutputEncoding>UTF-8</OutputEncoding>
+	<Query role="example" searchTerms="!g cats"/>
+</OpenSearchDescription>


### PR DESCRIPTION
This PR adds support for the OpenSearch standard, allowing users to add Unduck as a search engine in their browser. The opensearch.xml is based on YouTube's one. 

Changes:
- Adds an opensearch.xml file to the /public directory.
- Links to the XML file from index.html using <link rel="search">.


To Test:

- Open this deployment - https://unduck-ten.vercel.app/
- Your browser should now offer to add "Unduck" as a search engine (e.g., via the address bar menu in Firefox or in Chrome's search engine settings).
- Add it and test a search from the address bar.