### PR TITLE
feat: add modrinth support

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -11,6 +11,15 @@ export const bangs = [
     u: "https://www.t3.chat/new?q={{{s}}}",
   },
   {
+  c: "Tech",
+  d: "www.modrinth.com",
+  r: 0,
+  s: "Modrinth",
+  sc: "Downloads (add-ons)",
+  t: "modr",
+  u: "https://modrinth.com/mods?q={{{s}}}",
+  },
+  {
     c: "Tech",
     d: "www.01net.com",
     r: 4,


### PR DESCRIPTION
Adds a bang for [modrinth](https://modrinth.com), which is the best place to download minecraft modded content at the moment, as `!modr`