### PR TITLE
feat: add !gw for google web-only

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -122071,4 +122071,10 @@ export const bangs = [
     t: "\u10d0\u10e1\u10e2\u10e0\u10dd",
     u: "http://astronet.ge/?s={{{s}}}",
   },
+  {
+      t: "gw",
+      u: "https://www.google.com/search?q={{{s}}}&udm=14",
+      s: "Google (Web Only)",
+      c: "web",
+  },
 ];

--- a/src/bang.ts
+++ b/src/bang.ts
@@ -122072,9 +122072,9 @@ export const bangs = [
     u: "http://astronet.ge/?s={{{s}}}",
   },
   {
-      t: "gw",
-      u: "https://www.google.com/search?q={{{s}}}&udm=14",
-      s: "Google (Web Only)",
-      c: "web",
+    t: "gweb",
+    u: "https://www.google.com/search?q={{{s}}}&udm=14",
+    s: "Google (Web Only)",
+    c: "web",
   },
 ];


### PR DESCRIPTION
New bang for google search without the ai overview

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `!gweb` bang for Google web-only search
> Adds a new `gweb` bang to [bang.ts](https://github.com/T3-Content/unduck/pull/148/files#diff-e085323c54b237ec4e6d809e5128132e7f31da1a31c6cdf10538738071875831) that searches Google with the `udm=14` parameter, which filters results to web pages only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 707b32d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Google (Web Only)" search option accessible via the "gweb" keyword to produce web-only Google search results.
  * This new option integrates alongside existing search choices; no existing search entries were removed or modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->